### PR TITLE
improve switch between dokuwiki and ckg editors

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -570,13 +570,20 @@ $DW_EDIT_hide = $this->dw_edit_displayed();
             />
 
             <input type="checkbox" name="ckgedit" value="ckgedit" style="display: none"/>
-             
+            <?php
+	            $pos = strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE');
+	            if($pos === false) {
+	                $onclick = "setDWEditCookie(2, this);parent.window.location.reload(true);return false;";
+	            } else {
+	                $onclick = "window.event.cancelBubble = true;setDWEditCookie(2, this);parent.window.location.reload(true);return false;";
+	            }
+	        ?>
              <input class="button"  
                  <?php echo $DW_EDIT_disabled; ?>                 
                  <?php echo $DW_EDIT_hide; ?>
                  style = "font-size: 100%;"
-                 onclick ="setDWEditCookie(2, this);parse_wikitext('edbtn__save');this.form.submit();" 
-                 type="submit" name="do[save]" value="<?php echo $ckgedit_lang['btn_dw_edit']?>"  
+                 onclick ="<?php  echo $onclick;?>" 
+                 type="submit" name="" value="<?php echo $ckgedit_lang['btn_dw_edit']?>"  
                  title="<?php echo $ckgedit_lang['title_dw_edit']?>"
                   />
 

--- a/action/meta.php
+++ b/action/meta.php
@@ -93,10 +93,10 @@ if($_REQUEST['fck_preview_mode'] != 'nil' && !isset($_COOKIE['FCKW_USE']) && !$F
 
      $pos = strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE');
      if($pos === false) {
-                 $button['onclick'] = 'return setDWEditCookie(1, this);';
+     	$button['onclick'] = 'setDWEditCookie(1, this);document.location.reload(true);return false;';
      }
      else {
-                $button['onmousedown'] = 'return setDWEditCookie(1, this);';
+     	$button['onmousedown'] = 'setDWEditCookie(1, this);document.location.reload(true);return false;';
      }
 
     $pos = $event->data->findElementByAttribute('type','submit');
@@ -147,7 +147,6 @@ if($_REQUEST['fck_preview_mode'] != 'nil' && !isset($_COOKIE['FCKW_USE']) && !$F
             dom.value = 'dwiki';        
 
         }
-         e.form.submit();
     }
   
  


### PR DESCRIPTION
When clicking on button  "ckgedit" or "dokuwiki edit" we are redirected on view page instead of edit page (with editor switched).

Removing saving before switching because sometimes ckgedit break page so we want to switch on dokuwiki editor without ckgeditor breaking the page. If changes have been done, web browser ask to confirm to "quit" the current page.
