### PR TITLE
fixed method prototypes in order to purge PHP 7 warnings

### DIFF
--- a/action/delete.php
+++ b/action/delete.php
@@ -11,7 +11,7 @@ require_once(DOKU_PLUGIN.'action.php');
 class action_plugin_ckgedit_delete extends DokuWiki_Action_Plugin {
 
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'ckgedit_delete_preprocess');
     }
 

--- a/action/edit.php
+++ b/action/edit.php
@@ -31,7 +31,7 @@ class action_plugin_ckgedit_edit extends DokuWiki_Action_Plugin {
     }
 
 
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
        $version = explode('.', phpversion());
        define('PHP_VERSION_NUM', $version[0] * 10+ $version[1]);

--- a/action/meta.php
+++ b/action/meta.php
@@ -21,7 +21,7 @@ class action_plugin_ckgedit_meta extends DokuWiki_Action_Plugin {
   /*
    * Register its handlers with the dokuwiki's event controller
    */
-  function register(&$controller) {            
+  function register(Doku_Event_Handler $controller) {            
 
             if($this->helper->is_outOfScope()) return;
             $controller->register_hook( 'TPL_METAHEADER_OUTPUT', 'AFTER', $this, 'loadScript');    

--- a/action/save.php
+++ b/action/save.php
@@ -11,7 +11,7 @@ define('FCK_ACTION_SUBDIR', realpath(dirname(__FILE__)) . '/');
 
 class action_plugin_ckgedit_save extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
   
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'ckgedit_save_preprocess');
     }

--- a/renderer.php
+++ b/renderer.php
@@ -101,7 +101,7 @@ class renderer_plugin_ckgedit extends Doku_Renderer_xhtml
      * isolate table from bottom and top editor window margins
      * @author Myron Turner <turnermm02@shaw.ca>
      */
-    function table_close()
+    function table_close($pos = NULL)
     {
         global $conf;  
         $this->doc .= "</table>\n<span class='np_break'>&nbsp;</span>\n";

--- a/syntax/font.php
+++ b/syntax/font.php
@@ -32,7 +32,7 @@ class syntax_plugin_ckgedit_font extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
 
         switch ($state) {
@@ -60,7 +60,7 @@ class syntax_plugin_ckgedit_font extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             list($state, $match) = $data;
 

--- a/syntax/specials.php
+++ b/syntax/specials.php
@@ -66,7 +66,7 @@ class syntax_plugin_ckgedit_specials extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         $class = "";  
         $xhtml = "";
@@ -95,7 +95,7 @@ class syntax_plugin_ckgedit_specials extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             list($state, $xhtml) = $data;
             switch ($state) {


### PR DESCRIPTION
Using this plugin with a DokuWiki installation that uses PHP 7, several warnings popped up. I changed the method prototypes according to these warnings, i.e. make them comply to the current DokuWiki class definitions, e.g. the definition for register as register(Doku_Event_Handler $controller) in DokuWiki_Action_Plugin as defined in https://github.com/splitbrain/dokuwiki/blob/master/lib/plugins/action.php. The change regarding table_close() was a missing $pos parameter.