### PR TITLE
fix for _false_, switching in Chrome to dwedit and canceling edits

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-rev_17-Mar_02-10_31
+rev_17-Mar_04-15_59
 
 28 Feb 2013
 Added support for interwiki links

--- a/action/meta.php
+++ b/action/meta.php
@@ -295,8 +295,9 @@ if($_REQUEST['fck_preview_mode'] != 'nil' && !isset($_COOKIE['FCKG_USE']) && !$F
         else {            
             document.cookie = 'FCKG_USE=_false_;expires=';             
             dom.value = 'dwiki';        
-
-            if(window.dwfckTextChanged  && !window.confirm("$discard")) {            
+           if(JSINFO['chrome_version'] >= 56 && window.dwfckTextChanged) {
+           }
+            else if(window.dwfckTextChanged  && !window.confirm("$discard")) {            
                var dom = GetE('dwsave_select');                
                ckgedit_dwedit_reject=true;
                window.dwfckTextChanged = false;
@@ -558,10 +559,16 @@ function check_userfiles() {
        global $ID; 
        global $JSINFO;
        global  $INPUT;
+       global $updateVersion;
        
        $JSINFO['confirm_delete']= $this->getLang('confirm_delete');
        $JSINFO['doku_base'] = DOKU_BASE ;
        $JSINFO['cg_rev'] = $INPUT->str('rev');
+       $JSINFO['dw_version']  = (float)$updateVersion;
+       if(preg_match("/Chrome\/(\d+)/", $_SERVER['HTTP_USER_AGENT'],$cmatch)) {
+           $JSINFO['chrome_version']  = (float) $cmatch[1];
+       }
+       else $JSINFO['chrome_version'] = 0;
 	   $this->check_userfiles(); 
 	   $this->profile_dwpriority=($this->dokuwiki_priority && $this->in_dwpriority_group()) ? 1 :  0; 
        if(isset($_COOKIE['FCK_NmSp'])) $this->set_session(); 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base  ckgedit
 author  Myron Turner
 email  turnermm02@shaw.ca
-date 2017-03-02
+date 2017-03-04
 name  ckgedit
 desc  WYSIWYG plugin for Dokuwiki
 url  https://www.dokuwiki.org/plugin:ckgedit

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-_ckgEdit-ckedit_457-17-Mar_02-10_31
+_ckgEdit-ckedit_457-17-Mar_04-15_59


### PR DESCRIPTION
In Chrome, when switching to dw_edit and canceling  new data, the file is lost to a` _false_ `and the `_false_` is reported to the screen..  This fix auto-forces a save.