### PR TITLE
handle $conf['useheading'] correctly

### DIFF
--- a/action/save.php
+++ b/action/save.php
@@ -188,9 +188,9 @@ class action_plugin_ckgedit_save extends DokuWiki_Action_Plugin {
                    if($this->getConf('rel_links')) 
                       $current_id = $this->abs2rel($link_id,$ID); 
                     else  $current_id = $link_id;
-                   $useheading  = $conf['useheading'];
-                   if($useheading && $useheading != 'navigation') {
-                      $tmp_linktext = trim(tpl_pagetitle($link_id,1));                       
+                   //like in _getLinkTitle in xhtml.php
+                   if(useHeading('content')) {
+                      $tmp_linktext = p_get_first_heading($link_id);
                       if(trim($linktext) == trim($tmp_linktext)) {
                           $linktext = "";
                       }
@@ -199,7 +199,7 @@ class action_plugin_ckgedit_save extends DokuWiki_Action_Plugin {
                    $tmp_id = array_pop($tmp_ar);
                    if(trim($linktext,'.: ' ) == trim($tmp_id,'.: ')) $linktext = "";
                               
-                   $current_id = $current_id.'|'.$linktext;    
+                   $current_id = $current_id.'|'.$linktext;
                    return '[[' . $current_id .']]';
                },
            $TEXT


### PR DESCRIPTION
p_get_first_heading is the standard dokuwiki funciton for getting page link header and should be used instead tpl_pagetitle which will not always work.