### PR TITLE
Use regular Dokuwiki mechanism for registering changed text

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -378,6 +378,7 @@ function draft_delete() {
     }
     });
 
+    window.textChanged = false;
 }
 
 function disableDokuWikiLockTimer() {
@@ -467,6 +468,7 @@ function FCKeditor_OnComplete( editorInstance )
 
   CKEDITOR.instances.wiki__text.on('change', function(event) {
         window.dwfckTextChanged = true;
+        window.textChanged = true;
   });
 
   editorInstance.on("focus", function(e) {


### PR DESCRIPTION
With CKGEditor and the current stable (2018-04-22b "Greebo") and snapshot (2019-11-30) releases of Dokuwiki, the user was not warned when leaving the page without saving changes. This pull request uses the `textChanged` flag that is [checked by Dokuwiki](https://github.com/splitbrain/dokuwiki/blob/7377638a04c64b304fc25e73ed4ec62ce4e05645/lib/scripts/edit.js#L255) to warn the user.