### PR TITLE
Escape double-quotes in group-names to prevent javascript errors

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -150,6 +150,7 @@ class helper_plugin_ckgedit extends DokuWiki_Plugin {
 	 $user_type = 'visitor';
   }
   $user_groups = implode(";;",$user_groups);
+  $user_groups = str_replace('"','\"',implode(";;",$user_groups));
 
   if($INFO['isadmin'] || $INFO['ismanager']) {    
      $client = "";


### PR DESCRIPTION
We have some weird group names that include double quotes. This will break the editor as the javascript breaks with wrong quoting. This patch simply esacpes double quotes within the generated group string.