### PR TITLE
Escape double-quotes in group variable in js

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -150,6 +150,7 @@ class helper_plugin_ckgedit extends DokuWiki_Plugin {
 	 $user_type = 'visitor';
   }
   $user_groups = implode(";;",$user_groups);
+  $user_groups = str_replace('"','\"',implode(";;",$user_groups));
 
   if($INFO['isadmin'] || $INFO['ismanager']) {    
      $client = "";

--- a/helper.php
+++ b/helper.php
@@ -149,7 +149,6 @@ class helper_plugin_ckgedit extends DokuWiki_Plugin {
      $create_folder = 'n';
 	 $user_type = 'visitor';
   }
-  $user_groups = implode(";;",$user_groups);
   $user_groups = str_replace('"','\"',implode(";;",$user_groups));
 
   if($INFO['isadmin'] || $INFO['ismanager']) {    


### PR DESCRIPTION
We have some weird group names which include double quotes. This patch escpaes quotes in groupnames in javascript to prevent breaking the editor/javascript.