### PR TITLE
Fix issue 601

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -140,7 +140,7 @@ class action_plugin_ckgedit_edit extends DokuWiki_Action_Plugin {
          $nval = substr(md5(time()), -20);
          $parse_url = DOKU_URL . 'lib/plugins/ckgedit/scripts/parse_wiki.js.unc';
         }
-        else $parse_url = DOKU_URL . 'lib/plugins/ckgedit/scripts/parse_wiki-cmpr.js';
+        else $parse_url = DOKU_BASE . 'lib/plugins/ckgedit/scripts/parse_wiki-cmpr.js';
         $event->data['script'][] = 
             array( 
                 'type'=>'text/javascript', 

--- a/action/edit.php
+++ b/action/edit.php
@@ -599,7 +599,7 @@ if($fbsz_increment) {
     $fbrowser_height  =$fbrowser_height + ($fbrowser_height*($fbsz_increment/100));
 }
 
-$doku_url=  rtrim(DOKU_URL,'/');        
+$doku_base=  rtrim(DOKU_BASE,'/');        
 $ns = getNS($_COOKIE['FCK_NmSp']);
 
 //get user file browser if allowed
@@ -612,11 +612,11 @@ if ($this->getConf('allow_ckg_filebrowser') == 'all') {
 
 //setup options
 if ($fb == 'dokuwiki') {
-    $fbOptions = "filebrowserImageBrowseUrl: \"$doku_url/lib/exe/mediamanager.php?ns=$ns&edid=wiki__text&onselect=ckg_edit_mediaman_insert&ckg_media=img\",
-    filebrowserBrowseUrl: \"$doku_url/lib/exe/mediamanager.php?ns=$ns&edid=wiki__text&onselect=ckg_edit_mediaman_insertlink&ckg_media=link\"";
+    $fbOptions = "filebrowserImageBrowseUrl: \"$doku_base/lib/exe/mediamanager.php?ns=$ns&edid=wiki__text&onselect=ckg_edit_mediaman_insert&ckg_media=img\",
+    filebrowserBrowseUrl: \"$doku_base/lib/exe/mediamanager.php?ns=$ns&edid=wiki__text&onselect=ckg_edit_mediaman_insertlink&ckg_media=link\"";
 } else {
-    $fbOptions = "filebrowserImageBrowseUrl :  \"$doku_url/lib/plugins/ckgedit/fckeditor/editor/filemanager/browser/default/browser.html?Type=Image&Connector=$doku_url/lib/plugins/ckgedit/fckeditor/editor/filemanager/connectors/php/connector.php\",
-    filebrowserBrowseUrl: \"$doku_url/lib/plugins/ckgedit/fckeditor/editor/filemanager/browser/default/browser.html?Type=File&Connector=$doku_url/lib/plugins/ckgedit/fckeditor/editor/filemanager/connectors/php/connector.php\"";
+    $fbOptions = "filebrowserImageBrowseUrl :  \"$doku_base/lib/plugins/ckgedit/fckeditor/editor/filemanager/browser/default/browser.html?Type=Image&Connector=$doku_base/lib/plugins/ckgedit/fckeditor/editor/filemanager/connectors/php/connector.php\",
+    filebrowserBrowseUrl: \"$doku_base/lib/plugins/ckgedit/fckeditor/editor/filemanager/browser/default/browser.html?Type=File&Connector=$doku_base/lib/plugins/ckgedit/fckeditor/editor/filemanager/connectors/php/connector.php\"";
 }
 if($this->getConf('style_sheet')) {
 $contents_css = $this->alt_style_sheet();

--- a/action/save.php
+++ b/action/save.php
@@ -2,7 +2,7 @@
 if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../../').'/');
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 if(!defined('DOKU_MEDIA')) define('DOKU_MEDIA',DOKU_INC.'data/media/');
-define ('BROKEN_IMAGE', DOKU_URL . 'lib/plugins/ckgedit/fckeditor/userfiles/blink.jpg?nolink&33x34');
+define ('BROKEN_IMAGE', DOKU_BASE . 'lib/plugins/ckgedit/fckeditor/userfiles/blink.jpg?nolink&33x34');
 require_once(DOKU_PLUGIN.'action.php');
 define('FCK_ACTION_SUBDIR', realpath(dirname(__FILE__)) . '/');
 /**

--- a/helper.php
+++ b/helper.php
@@ -131,7 +131,7 @@ class helper_plugin_ckgedit extends DokuWiki_Plugin {
   else {
    $user_type = 'user';
   }
-  $save_dir = DOKU_URL . ltrim($conf['savedir'],'/.\/');
+  $save_dir = DOKU_BASE . ltrim($conf['savedir'],'/.\/');
   $fbsz_increment = isset($_COOKIE['fbsz']) && $_COOKIE['fbsz'] ? $_COOKIE['fbsz'] : '0';
   $use_pastebase64 = (isset($_COOKIE['ckgEdPaste']) && $_COOKIE['ckgEdPaste'] == 'on' )  ? 'on' : 'off';
   // if no ACL is used always return upload rights


### PR DESCRIPTION
Fixing Issue #601 
Using DOKU_BASE instead of DOKU_URL - this avoids the hardcoded "http://" in DOKU_URL which can create a "mixed active content error" when not all urls are rewritten from http to https by the webserver. 

Several instances of DOKU_URL were not changed, either because they are in code that is commented-out or look like special test-case code (edit.php line 141)

