### PR TITLE
Check if link option is a string before applying match()

### DIFF
--- a/script.js
+++ b/script.js
@@ -438,6 +438,9 @@ function ckg_edit_mediaman_insert(edid, id, opts, dw_align) {
     link = 'detail';
     for (var i in options) {
         var opt = options[i];
+        if (typeof opt !== 'string') {
+            continue;
+        }
          if (opt.match(/^\d+$/)) {   
             width = opt;
         } else  if (opt.match(/^\w+$/)) {   


### PR DESCRIPTION
This is a minor change that just checks if a value is actually a string before executing a string function on it (`String.match()`). So it doesn't have any side effects.

The missing check causes us problems in the sprintdoc template. We extend the array prototype and our function is processed as one of the link options in the `for` loop. That breaks some of media manager functionality.