### PR TITLE
Fix retrieval of the alternate stylesheet

### DIFF
--- a/action/edit.php
+++ b/action/edit.php
@@ -529,7 +529,7 @@ class action_plugin_ckgedit_edit extends DokuWiki_Action_Plugin {
                while (!feof($fh) &&  $line_num < 4) {
                     $line = fgets($fh,1024);            //msg($line);      
                     if(strpos($line,$tpl_name)!==false) {
-                         return DOKU_BASE . '/lib/plugins/ckgedit/ckeditor/css/_style.css' ;
+                         return DOKU_URL . '/lib/plugins/ckgedit/ckeditor/css/_style.css' ;
                         break;
                      }   
                     $line_num ++;                     


### PR DESCRIPTION
The link to retrieve the alternate _style.css is wrongly generated, this will fix it (tested in my environment on Igor release).