### PR TITLE
use of realpath to resolve properly relative_dir

### DIFF
--- a/fckeditor/editor/filemanager/connectors/php/config.php
+++ b/fckeditor/editor/filemanager/connectors/php/config.php
@@ -196,7 +196,7 @@ function setupBasePathsNix() {
     
     $dir = preg_replace('/editor\/filemanager\/connectors\/.*/', "$animal/",$dir);
     $Config['UserFilesAbsolutePath'] = $dir;
-    $document_root = $_SERVER['DOCUMENT_ROOT'];
+    $document_root = realpath($_SERVER['DOCUMENT_ROOT']);
     $relative_dir = str_replace($document_root, "", $dir);
     $Config['UserFilesPath'] = $relative_dir;
 }


### PR DESCRIPTION
As path directory may be a symbolic link in $_SERVER['DOCUMENT_ROOT'], to remove it from $document_root we need to use php realpath function to remove it and solve correctly the relative path