### PR TITLE
Correct small Bugs with php 8.030 for not generate erros log

### DIFF
--- a/action/meta.php
+++ b/action/meta.php
@@ -385,8 +385,34 @@ function replace_entities() {
         return;
    }
 
+
+
+
   // restore preview button if standard DW editor is in place
   // $FCKG_show_preview is set in edit.php in the register() function
+
+
+
+
+if (isset($_REQUEST['fck_preview_mode'])) {
+    if ($_REQUEST['fck_preview_mode'] != 'nil' && !isset($_COOKIE['FCKG_USE']) && !empty($FCKG_show_preview)) {
+        echo '<style type="text/css">#edbtn__preview { display:none; }</style>';
+    } elseif (!empty($FCKG_show_preview)) {
+        echo '<style type="text/css">#edbtn__preview { display: inline; } </style>';
+    } else {
+        echo '<style type="text/css">#edbtn__preview, .btn_show { position:absolute }</style>';
+    }
+
+    global $ckgedit_lang;
+
+    if ($_REQUEST['fck_preview_mode'] == 'preview') {
+        return;
+    }
+}
+
+
+
+/*
 if($_REQUEST['fck_preview_mode'] != 'nil' && !isset($_COOKIE['FCKG_USE']) && !$FCKG_show_preview) {    
      echo '<style type="text/css">#edbtn__preview { display:none; }</style>';
  }
@@ -402,6 +428,7 @@ if($_REQUEST['fck_preview_mode'] != 'nil' && !isset($_COOKIE['FCKG_USE']) && !$F
   if($_REQUEST['fck_preview_mode']== 'preview'){
     return;
   }
+*/
 
  $param = array();
  $this->preprocess($event, $param);  // create the setDWEditCookie() js function
@@ -823,12 +850,21 @@ function check_userfiles() {
        setcookieSameSite('FCK_NmSp',$ID, $expire, '/');     
       
           
+// Verifica se a chave 'TopLevel' está definida no array $_COOKIE
+if (isset($_COOKIE['TopLevel'])) {
+    // Verifica se $_REQUEST['TopLevel'] está definido
+    $topLevelValue = isset($_REQUEST['TopLevel']) ? $_REQUEST['TopLevel'] : '';
+
+    // Remove o cookie 'TopLevel'
+    setcookieSameSite("TopLevel", $topLevelValue, time() - 3600, '/');
+}
 
       /* Remove TopLevel cookie */         
+/*
        if(isset($_COOKIE['TopLevel'])) {
             setcookieSameSite("TopLevel", $_REQUEST['TopLevel'], time()-3600, '/');
        }
-
+*/
      
        if(!isset($_REQUEST['id']) || isset($ACT['preview'])) return;
        if(isset($_REQUEST['do']) && isset($_REQUEST['do']['edit'])) {
@@ -916,7 +952,7 @@ function reset_user_rewrite_check() {
 	     $conf['userewrite']  = 0; 
        }
       
-       if($conf['htmlok'] || $this->getConf('htmlblock_ok')) { 
+       if((isset($conf['htmlok'])&& $conf['htmlok']) || $this->getConf('htmlblock_ok')) { 
          $JSINFO['htmlok'] = 1;
     }	  
     else $JSINFO['htmlok'] = 0;

--- a/action/save.php
+++ b/action/save.php
@@ -221,7 +221,7 @@ $TEXT = preg_replace_callback("#<code\s+(\w+)>.*?(\[enable_line_numbers.*?\])\s*
                    }                
                 
                    $link = explode('?',$matches[1]);
-                   if($link[1]) {                       
+                   if (isset($link[1])) {                       
                        $link_id = $link[0];
                        list($qs,$linktext) = explode('|', $link[1]);     
                    }

--- a/admin.php
+++ b/admin.php
@@ -55,6 +55,12 @@ class admin_plugin_ckgedit extends DokuWiki_Admin_Plugin {
 	  echo $this->getLang('stylesheet_oinfo');
 	  ptln('</button>');
 		  
+      $ID = ""; // Initialize $ID with an empty string
+      //----- Correction Start
+      if (isset($_REQUEST['ID'])) {
+          $ID = $_REQUEST['ID']; // Assign the value from $_REQUEST['ID'] to $ID
+      }      
+      //---- Correction End 
       ptln('<form action="'.wl($ID).'" method="post">'); 
       // output hidden values to ensure dokuwiki will return back to this plugin
       ptln('  <input type="hidden" name="do"   value="admin" />');
@@ -75,8 +81,8 @@ class admin_plugin_ckgedit extends DokuWiki_Admin_Plugin {
       ptln('</select>');
 	  ptln('<input type="submit" name="cmd[alt_stylesheet]"  value="'.$this->getLang('style_sheet').'" />');   
       ptln('</form></p>');   
-
-	  if($this->output && $this->output == 'style_sheet_msg') {	  
+      
+      if($this->output && $this->output == 'style_sheet_msg') {	  
           $path = $this->tpl_inc;     
 		  ptln(htmlspecialchars($this->getLang($this->output)). " " .$this->template);	  
 		  $retv = css_ckg_out($path);

--- a/scripts/css6.php
+++ b/scripts/css6.php
@@ -234,6 +234,7 @@ function css_ckg_styleini($tpl) {
     $incbase = tpl_incdir($tpl);
     $webbase = tpl_basedir($tpl);
     $ini = $incbase.'style.ini';
+$data = []; // Define a variável <link>$data</link> como um array vazio
     if(file_exists($ini)){
         $data = parse_ini_file($ini, true);
 


### PR DESCRIPTION
I just apply small corrections on 4 files:
admin.php
save.php
meta.php
css6.php

The current version works without problens however her generate error logs for some variables on php 8.0.30 and wiki Release 2023-04-04a "Jack Jackrum"

Erros:
E_WARNING: Undefined variable $data
/var/www/html/wikipossetup/lib/plugins/ckgedit/scripts/css6.php(469)

 Undefined array key "TopLevel"
/var/www/html/wikipossetup/lib/plugins/ckgedit/action/meta.php(829)

E_WARNING: Undefined array key "fck_preview_mode"
/var/www/html/wikipossetup/lib/plugins/ckgedit/action/meta.php(397 or 390)

...

The only next plugin i have was instaled.
Clipboard Utils Plugin